### PR TITLE
페이지 상단 올리기 버튼 구현 + DetailTab 스크롤 방향에 따른 display 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import { Routes, Route } from 'react-router-dom';
 import Main from './pages/main';
 import IndexPage from './pages/index';
-import About from './pages/about';
 import Project from 'pages/Project';
 import DetailProject from 'pages/DetailProject';
 import Designers from 'pages/Designers';
 import DetailDesigner from 'pages/DetailDesigner';
+import About from 'pages/About';
 
 function App() {
   return (

--- a/src/Asset/to-the-top.svg
+++ b/src/Asset/to-the-top.svg
@@ -1,0 +1,23 @@
+<svg width="144" height="144" viewBox="0 0 144 144" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_dd_1124_5170)">
+<circle cx="72" cy="64" r="40" fill="white"/>
+<circle cx="72" cy="64" r="39.5" stroke="#E8E8E8"/>
+</g>
+<path d="M72.5 57L73.1946 56.2806L72.5 55.61L71.8054 56.2806L72.5 57ZM86.3054 71.7194L87.0248 72.414L88.414 70.9752L87.6946 70.2806L86.3054 71.7194ZM58.6946 71.7194L73.1946 57.7194L71.8054 56.2806L57.3054 70.2806L58.6946 71.7194ZM71.8054 57.7194L86.3054 71.7194L87.6946 70.2806L73.1946 56.2806L71.8054 57.7194Z" fill="#A8A8A8"/>
+<defs>
+<filter id="filter0_dd_1124_5170" x="0" y="0" width="144" height="144" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="8"/>
+<feGaussianBlur stdDeviation="16"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1124_5170"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="2"/>
+<feGaussianBlur stdDeviation="10"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_1124_5170" result="effect2_dropShadow_1124_5170"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_1124_5170" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/Form/DetailTabs/DetailTabs.module.scss
+++ b/src/components/Form/DetailTabs/DetailTabs.module.scss
@@ -5,6 +5,7 @@
   gap: 40px;
   justify-content: center;
   margin-top: 51px;
+  transition: none;
 
   @include media.media-breakpoint(mobile) {
     position: fixed;
@@ -14,10 +15,11 @@
     margin-top: 0px;
     background-color: white;
     transition: transform 0.3s ease;
-  }
-  &--hide {
-    transform: translateY(-101%);
-    transition: transform 0.3s ease;
+
+    &--hide {
+      transform: translateY(-101%);
+      transition: transform 0.3s ease;
+    }
   }
 }
 

--- a/src/components/Form/DetailTabs/DetailTabs.module.scss
+++ b/src/components/Form/DetailTabs/DetailTabs.module.scss
@@ -7,8 +7,17 @@
   margin-top: 51px;
 
   @include media.media-breakpoint(mobile) {
+    position: fixed;
+    width: 100%;
+    z-index: 100;
     gap: 0px;
     margin-top: 0px;
+    background-color: white;
+    transition: transform 0.3s ease;
+  }
+  &--hide {
+    transform: translateY(-101%);
+    transition: transform 0.3s ease;
   }
 }
 

--- a/src/components/Form/DetailTabs/DetailTabs.module.scss
+++ b/src/components/Form/DetailTabs/DetailTabs.module.scss
@@ -4,9 +4,11 @@
   display: flex;
   gap: 40px;
   justify-content: center;
+  margin-top: 51px;
 
   @include media.media-breakpoint(mobile) {
     gap: 0px;
+    margin-top: 0px;
   }
 }
 

--- a/src/components/Form/DetailTabs/index.tsx
+++ b/src/components/Form/DetailTabs/index.tsx
@@ -7,14 +7,17 @@ interface DetailTabsProps {
   tabs: any;
   selected: any;
   projectType?: boolean;
+  showNav?: boolean;
 }
 
-function DetailTabs({ tabs, selected, projectType }: DetailTabsProps) {
+function DetailTabs({ tabs, selected, projectType, showNav }: DetailTabsProps) {
   return (
     <div
       className={cn({
         [styles['project-tab-button-section']]: projectType === true,
         [styles['tab-button-section']]: projectType === undefined,
+        [styles['tab-button-section--hide']]: showNav === false,
+        // [styles['hide-nav']]: showNav === false,
       })}
     >
       {tabs.map((tab: { name: any; onClick: any }) => (

--- a/src/components/MobileHeader/index.tsx
+++ b/src/components/MobileHeader/index.tsx
@@ -21,77 +21,65 @@ export default function MobileHeader() {
   };
 
   return (
-    <div className={cn({
-      [styles.header]: true,
-      [styles['header--on']]: menuToggle,
-    })}>
-      <div className={cn({
+    <div
+      className={cn({
+        [styles.header]: true,
+        [styles['header--on']]: menuToggle,
+      })}
+    >
+      <div
+        className={cn({
           [styles.header__top]: true,
           [styles['header__top--on']]: menuToggle,
-      })}>
-        <MobileLogo 
+        })}
+      >
+        <MobileLogo
           className={cn({
             [styles.header__logo]: menuToggle,
-          })} 
+          })}
           onClick={() => navigate('/')}
         />
-      {
-        menuToggle ? (
-          <XIcon 
-            onClick={(e) => onClickToggle(e)}
-            aria-hidden
-          />
+        {menuToggle ? (
+          <XIcon onClick={(e) => onClickToggle(e)} aria-hidden />
         ) : (
-          <MobileMenu
-            onClick={(e) => onClickToggle(e)}
-            aria-hidden
-          />
-        )
-      }
-     </div>
-     <div className={cn({
-        [styles.menu]: true,
-        [styles['menu--on']]: menuToggle,
-      })}>
-      <div className={
-        styles.menu__content
-      }>
-        <div 
-          className={cn({
-            [styles.item]: true,
-            [styles.item__first]: true,
-            [styles['item--on']]: aboutToggle,
-          })}
-          onClick={(e) => onClickAboutToggle(e)}
-        >
-          ABOUT
+          <MobileMenu onClick={(e) => onClickToggle(e)} aria-hidden />
+        )}
+      </div>
+      <div
+        className={cn({
+          [styles.menu]: true,
+          [styles['menu--on']]: menuToggle,
+        })}
+      >
+        <div className={styles.menu__content}>
           <div
-            className={
-              cn({
+            className={cn({
+              [styles.item]: true,
+              [styles.item__first]: true,
+              [styles['item--on']]: aboutToggle,
+            })}
+            onClick={(e) => onClickAboutToggle(e)}
+          >
+            ABOUT
+            <div
+              className={cn({
                 [styles.item__list]: true,
                 [styles['item__list--on']]: aboutToggle,
-              })
-            }
-          >
-            <div className={styles.item__link}>
-              전시 소개
-            </div>
-            <div className={styles.item__link}>
-              학과 소개
+              })}
+            >
+              <div className={styles.item__link}>전시 소개</div>
+              <div className={styles.item__link}>학과 소개</div>
             </div>
           </div>
-        </div>
-        <Link className={styles.item} to="/project">
-          PROJECT
-        </Link>
-        <Link className={styles.item} to="/designer">
-          DESIGNER
-        </Link>
-        <div className={styles.item}>
-          29th
+          <Link className={styles.item} to="/project">
+            PROJECT
+          </Link>
+          <Link className={styles.item} to="/designer">
+            DESIGNER
+          </Link>
+          <div className={styles.item}>29th</div>
         </div>
       </div>
-     </div>
     </div>
   );
 }

--- a/src/components/TopButton/TopButton.module.scss
+++ b/src/components/TopButton/TopButton.module.scss
@@ -1,0 +1,6 @@
+@use 'src/utils/scss/media';
+
+.scroll-to-top {
+  border: none;
+  background: none;
+}

--- a/src/components/TopButton/TopButton.module.scss
+++ b/src/components/TopButton/TopButton.module.scss
@@ -3,4 +3,7 @@
 .scroll-to-top {
   border: none;
   background: none;
+  & > svg {
+    cursor: pointer;
+  }
 }

--- a/src/components/TopButton/index.tsx
+++ b/src/components/TopButton/index.tsx
@@ -1,10 +1,7 @@
 import { ReactComponent as ToTheTopIcon } from 'Asset/to-the-top.svg';
-import { useEffect, useState } from 'react';
 import styles from './TopButton.module.scss';
 
 function TopButton() {
-  // const [showButton, setShowButton] = useState(false);
-
   const scrollToTop = () => {
     window.scroll({
       top: 0,
@@ -12,24 +9,8 @@ function TopButton() {
     });
   };
 
-  // useEffect(() => {
-  //   const showButtonClick = () => {
-  //     if (window.screenY > 0) {
-  //       setShowButton(true);
-  //     } else {
-  //       setShowButton(false);
-  //     }
-  //   };
-  //   window.addEventListener('scroll', showButtonClick);
-  //   return () => {
-  //     window.removeEventListener('scroll', showButtonClick);
-  //   };
-  // }, []);
-
   return (
     <>
-      {/* {showButton && ( */}
-
       <button
         onClick={scrollToTop}
         className={styles['scroll-to-top']}
@@ -37,8 +18,6 @@ function TopButton() {
       >
         <ToTheTopIcon />
       </button>
-
-      {/* )} */}
     </>
   );
 }

--- a/src/components/TopButton/index.tsx
+++ b/src/components/TopButton/index.tsx
@@ -1,0 +1,46 @@
+import { ReactComponent as ToTheTopIcon } from 'Asset/to-the-top.svg';
+import { useEffect, useState } from 'react';
+import styles from './TopButton.module.scss';
+
+function TopButton() {
+  // const [showButton, setShowButton] = useState(false);
+
+  const scrollToTop = () => {
+    window.scroll({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  // useEffect(() => {
+  //   const showButtonClick = () => {
+  //     if (window.screenY > 0) {
+  //       setShowButton(true);
+  //     } else {
+  //       setShowButton(false);
+  //     }
+  //   };
+  //   window.addEventListener('scroll', showButtonClick);
+  //   return () => {
+  //     window.removeEventListener('scroll', showButtonClick);
+  //   };
+  // }, []);
+
+  return (
+    <>
+      {/* {showButton && ( */}
+
+      <button
+        onClick={scrollToTop}
+        className={styles['scroll-to-top']}
+        type="button"
+      >
+        <ToTheTopIcon />
+      </button>
+
+      {/* )} */}
+    </>
+  );
+}
+
+export default TopButton;

--- a/src/pages/Designers/Designers.module.scss
+++ b/src/pages/Designers/Designers.module.scss
@@ -57,3 +57,10 @@
     align-items: center;
   }
 }
+
+.top-button {
+  z-index: 1000;
+  position: fixed;
+  right: 30px;
+  bottom: 15px;
+}

--- a/src/pages/Designers/index.tsx
+++ b/src/pages/Designers/index.tsx
@@ -1,6 +1,7 @@
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import styles from './Designers.module.scss';
 import DetailDesignerItem from './components/DetailDesignerItem';
+import TopButton from 'components/TopButton';
 
 function Designers() {
   const isMobile = useMediaQuery();
@@ -12,7 +13,11 @@ function Designers() {
           “ 여기, 38명의 디자이너 그리고 38개의 씨앗 ”
         </span>
       )}
-
+      {!isMobile && (
+        <div className={styles['top-button']}>
+          <TopButton />
+        </div>
+      )}
       <div className={styles['item-container']}>
         <div className={styles['item-section']}>
           <DetailDesignerItem />

--- a/src/pages/DetailDesigner/DetailDesigner.module.scss
+++ b/src/pages/DetailDesigner/DetailDesigner.module.scss
@@ -1,6 +1,5 @@
 @use 'src/utils/scss/media';
 
-
 .template {
   width: 100%;
   display: flex;
@@ -44,7 +43,7 @@
   &__info {
     width: 564px;
     margin-left: 132px;
-  
+
     @include media.media-breakpoint(mobile) {
       width: calc(100% - 48px);
       padding: 0 24px;
@@ -74,20 +73,20 @@
   }
 
   &__title {
-    color:  #262626;
+    color: #262626;
     font-family: Pretendard;
     font-size: 40px;
     font-style: normal;
     font-weight: 600;
     line-height: 120%; /* 48px */
     letter-spacing: -0.44px;
-  
+
     &--mobile {
       display: none;
-  
+
       @include media.media-breakpoint(mobile) {
         display: flex;
-        color: #FFF;
+        color: #fff;
         font-family: Pretendard;
         height: 38px;
         font-size: 24px;
@@ -100,7 +99,7 @@
   }
 
   &__en {
-    color: #BFBFBF;
+    color: #bfbfbf;
     font-family: Pretendard;
     font-size: 16px;
     font-style: normal;
@@ -112,10 +111,10 @@
 
     &--mobile {
       display: none;
-  
+
       @include media.media-breakpoint(mobile) {
         display: flex;
-        color:#FFF;
+        color: #fff;
         font-family: Pretendard;
         height: 29px;
         font-size: 18px;
@@ -135,7 +134,7 @@
   height: 59px;
   padding: 16px;
   border-radius: 8px;
-  background:#F5F8FF;
+  background: #f5f8ff;
   margin-bottom: 36px;
 
   @include media.media-breakpoint(mobile) {
@@ -147,7 +146,7 @@
   }
 
   &__header {
-    color: #B9D3FF;
+    color: #b9d3ff;
     font-family: Pretendard;
     font-size: 16px;
     font-style: normal;
@@ -156,7 +155,7 @@
     margin-bottom: 8px;
 
     @include media.media-breakpoint(mobile) {
-      color:  #B9D3FF;
+      color: #b9d3ff;
       font-family: Pretendard;
       font-size: 14px;
       font-style: normal;
@@ -166,7 +165,7 @@
   }
 
   &__content {
-    color:#7EA1DB;
+    color: #7ea1db;
     font-family: Pretendard;
     font-size: 20px;
     font-style: normal;
@@ -175,7 +174,7 @@
     letter-spacing: -0.22px;
 
     @include media.media-breakpoint(mobile) {
-      color:#7EA1DB;
+      color: #7ea1db;
       font-family: Pretendard;
       font-size: 18px;
       font-style: normal;
@@ -237,20 +236,20 @@
 
   &__title {
     width: 83px;
-    color: #6170B5;
+    color: #6170b5;
     font-family: Pretendard;
     font-size: 40px;
     font-style: normal;
     font-weight: 600;
     line-height: 120%; /* 48px */
     letter-spacing: -0.44px;
-    border-bottom: 3px solid #6170B5;
+    border-bottom: 3px solid #6170b5;
     justify-content: center;
     align-items: center;
 
     @include media.media-breakpoint(mobile) {
       width: 39px;
-      color: #6170B5;
+      color: #6170b5;
       font-family: Pretendard;
       font-size: 18px;
       font-style: normal;
@@ -280,7 +279,7 @@
 
   &__head {
     width: 100%;
-    color:#454545;
+    color: #454545;
     font-family: Pretendard;
     font-size: 24px;
     font-style: normal;
@@ -297,7 +296,7 @@
       font-style: normal;
       font-weight: 700;
       line-height: normal;
-      border-bottom: 0.5px solid #6888BE;
+      border-bottom: 0.5px solid #6888be;
       padding-bottom: 9px;
       margin-bottom: 9px;
     }
@@ -333,3 +332,9 @@
   }
 }
 
+.top-button {
+  z-index: 1000;
+  position: fixed;
+  right: 30px;
+  bottom: 15px;
+}

--- a/src/pages/DetailDesigner/index.tsx
+++ b/src/pages/DetailDesigner/index.tsx
@@ -1,11 +1,20 @@
-import { ReactComponent as  LinkLogo } from './Assets/link_logo.svg';
-import { ReactComponent as  InstaLogo } from './Assets/insta_logo.svg';
+import { ReactComponent as LinkLogo } from './Assets/link_logo.svg';
+import { ReactComponent as InstaLogo } from './Assets/insta_logo.svg';
 import { ReactComponent as MessageLogo } from './Assets/message_logo.svg';
 import styles from './DetailDesigner.module.scss';
+import TopButton from 'components/TopButton';
+import useMediaQuery from 'utils/hooks/useMediaQuery';
 
 function DetailDesigner() {
+  const isMobile = useMediaQuery();
+
   return (
     <div className={styles.template}>
+      {!isMobile && (
+        <div className={styles['top-button']}>
+          <TopButton />
+        </div>
+      )}
       <div className={styles.profile}>
         <div className={styles.profile__image}>
           이미지
@@ -21,11 +30,14 @@ function DetailDesigner() {
           </div>
           <div className={styles.word}>
             <div className={styles.word__header}>김다준의 한마디</div>
-            <div className={styles.word__content}>나는 자랑스러운 태극기앞에 말랑뱅구 다식이 최고 이제 졸업이다.</div>
+            <div className={styles.word__content}>
+              나는 자랑스러운 태극기앞에 말랑뱅구 다식이 최고 이제 졸업이다.
+            </div>
           </div>
           <div className={styles.links}>
             <div className={styles.links__item}>
-              <MessageLogo className={styles.links__logo} /> autumn0205@koreatech.ac.kr
+              <MessageLogo className={styles.links__logo} />{' '}
+              autumn0205@koreatech.ac.kr
             </div>
             <div className={styles.links__item}>
               <InstaLogo className={styles.links__logo} /> @the__autum.n
@@ -48,7 +60,10 @@ function DetailDesigner() {
             </div>
             <div className={styles.card__tail}>
               <div className={styles.card__answer}>
-              2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을 만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다. ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관 2021년도에는 응애응애 신입생이던 제가
+                2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을
+                만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다.
+                ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관
+                2021년도에는 응애응애 신입생이던 제가
               </div>
             </div>
           </div>
@@ -56,13 +71,17 @@ function DetailDesigner() {
             <div className={styles.card__head}>
               <div className={styles.card__title}>Q2.</div>
               <div className={styles.card__question}>
-                작품을 통해 전달하고자 하는 메시지나,<br />
+                작품을 통해 전달하고자 하는 메시지나,
+                <br />
                 사용자에게 전달하고자 하는 경험은 무엇인가요?
               </div>
             </div>
             <div className={styles.card__tail}>
               <div className={styles.card__answer}>
-              2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을 만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다. ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관 2021년도에는 응애응애 신입생이던 제가
+                2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을
+                만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다.
+                ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관
+                2021년도에는 응애응애 신입생이던 제가
               </div>
             </div>
           </div>
@@ -70,13 +89,17 @@ function DetailDesigner() {
             <div className={styles.card__head}>
               <div className={styles.card__title}>Q3.</div>
               <div className={styles.card__question}>
-              작품을 만들면서 가장 큰 도전은 무엇이었나요?<br />
-              이를 어떻게 극복했나요?
+                작품을 만들면서 가장 큰 도전은 무엇이었나요?
+                <br />
+                이를 어떻게 극복했나요?
               </div>
             </div>
             <div className={styles.card__tail}>
               <div className={styles.card__answer}>
-              2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을 만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다. ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관 2021년도에는 응애응애 신입생이던 제가
+                2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을
+                만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다.
+                ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관
+                2021년도에는 응애응애 신입생이던 제가
               </div>
             </div>
           </div>
@@ -84,14 +107,19 @@ function DetailDesigner() {
             <div className={styles.card__head}>
               <div className={styles.card__title}>Q4.</div>
               <div className={styles.card__question}>
-              개발한 디자인 또는 기술적 도약이<br />
-              어떤 새로운 가능성을 열어주었고, 이를 통해<br />
-              자신이 어떻게 성장했는지 간단히 이야기 해주세요.
+                개발한 디자인 또는 기술적 도약이
+                <br />
+                어떤 새로운 가능성을 열어주었고, 이를 통해
+                <br />
+                자신이 어떻게 성장했는지 간단히 이야기 해주세요.
               </div>
             </div>
             <div className={styles.card__tail}>
               <div className={styles.card__answer}>
-              2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을 만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다. ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관 2021년도에는 응애응애 신입생이던 제가
+                2021년도에는 응애응애 신입생이던 제가 드디어 2024년, 졸업작품을
+                만들고 드디어 졸업을 할 줄 알았으나 사실 내년에 졸업하게 됩니다.
+                ㅋ 속았지. 아무튼 졸업 전시 합니다. 졸업 전시 많관부~승관
+                2021년도에는 응애응애 신입생이던 제가
               </div>
             </div>
           </div>

--- a/src/pages/Project/index.tsx
+++ b/src/pages/Project/index.tsx
@@ -1,12 +1,15 @@
 import DetailTabs from 'components/Form/DetailTabs';
 import styles from './project.module.scss';
 import AllSection from './components/AllSection';
+import TopButton from 'components/TopButton';
+import useMediaQuery from 'utils/hooks/useMediaQuery';
 
 const TAB_LIST = ['All', 'Mobility', 'Care', 'Living'];
 
 function Project() {
   //전체 project
   const { tabs, currentTab } = DetailTabs.useTabs(TAB_LIST);
+  const isMobile = useMediaQuery();
 
   return (
     <>
@@ -15,6 +18,11 @@ function Project() {
       {currentTab === TAB_LIST[1] && <>Mobility</>}
       {currentTab === TAB_LIST[2] && <>Care</>}
       {currentTab === TAB_LIST[3] && <>Living</>}
+      {!isMobile && (
+        <div className={styles['top-button']}>
+          <TopButton />
+        </div>
+      )}
     </>
   );
 }

--- a/src/pages/Project/project.module.scss
+++ b/src/pages/Project/project.module.scss
@@ -1,1 +1,8 @@
 @use 'src/utils/scss/media';
+
+.top-button {
+  z-index: 1000;
+  position: fixed;
+  right: 30px;
+  bottom: 15px;
+}

--- a/src/pages/about/about.module.scss
+++ b/src/pages/about/about.module.scss
@@ -1,1 +1,8 @@
-@use "src/utils/scss/media";
+@use 'src/utils/scss/media';
+
+.top-button {
+  z-index: 1000;
+  position: fixed;
+  right: 30px;
+  bottom: 15px;
+}

--- a/src/pages/about/components/ExhibitIntroduce/ExhibitIntroduce.module.scss
+++ b/src/pages/about/components/ExhibitIntroduce/ExhibitIntroduce.module.scss
@@ -1,6 +1,7 @@
 @use 'src/utils/scss/media';
 
 .container {
+  position: relative;
   margin: 0 auto;
   max-width: 1920px;
 

--- a/src/pages/about/components/ExhibitIntroduce/ExhibitIntroduce.module.scss
+++ b/src/pages/about/components/ExhibitIntroduce/ExhibitIntroduce.module.scss
@@ -7,6 +7,7 @@
 
   @include media.media-breakpoint(mobile) {
     min-width: 375px;
+    padding-top: 51px;
     // & > img {
     //   display: flex;
     //   margin: 0 auto;

--- a/src/pages/about/components/ExhibitIntroduce/index.tsx
+++ b/src/pages/about/components/ExhibitIntroduce/index.tsx
@@ -5,6 +5,7 @@ import exhibitMap from './Asset/exhibitionMap.png';
 import mobility from './Asset/mobility.png';
 import care from './Asset/care.png';
 import living from './Asset/living.png';
+import { ReactComponent as ToTheTopIcon } from 'Asset/to-the-top.svg';
 
 import { ReactComponent as KoreatechIcon } from 'Asset/koreatech.svg';
 import { ReactComponent as DscIcon } from 'Asset/dsc.svg';
@@ -12,6 +13,7 @@ import { ReactComponent as IdeIcon } from 'Asset/ide.svg';
 import { ReactComponent as LincIcon } from 'Asset/linc.svg';
 import { ReactComponent as SeedkeeperIcon } from 'Asset/seedkeeper.svg';
 import { ReactComponent as SmartHumanInterfaceIcon } from 'Asset/smart-human-interface.svg';
+import TopButton from 'components/TopButton';
 
 const MEMBERS = [
   {

--- a/src/pages/about/components/MajorIntroduce/index.tsx
+++ b/src/pages/about/components/MajorIntroduce/index.tsx
@@ -7,6 +7,7 @@ import Jungjuyoung from './Asset/Jungjuyoung.png';
 import Kimtaegyun from './Asset/Kimtaegyun.png';
 import Yoonjeongsik from './Asset/Yoonjeongsik.png';
 import Yoonjinpil from './Asset/Yoonjinpil.png';
+import TopButton from 'components/TopButton';
 
 const OTHER_PROFESSOR = [
   { img: Yoonjeongsik, name: '윤정식 교수' },

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,17 +1,26 @@
 import DetailTabs from 'components/Form/DetailTabs';
 import MajorIntroduce from './components/MajorIntroduce';
 import ExhibitIntroduce from './components/ExhibitIntroduce';
+import TopButton from 'components/TopButton';
+import useMediaQuery from 'utils/hooks/useMediaQuery';
+import styles from './about.module.scss';
 
 const TAB_LIST = ['전시 소개', '학과 소개'];
 
 export default function About() {
   const { tabs, currentTab } = DetailTabs.useTabs(TAB_LIST);
+  const isMobile = useMediaQuery();
 
   return (
     <div>
       <DetailTabs tabs={tabs} selected={currentTab} />
       {currentTab === TAB_LIST[0] && <ExhibitIntroduce />}
       {currentTab === TAB_LIST[1] && <MajorIntroduce />}
+      {!isMobile && (
+        <div className={styles['top-button']}>
+          <TopButton />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -4,16 +4,18 @@ import ExhibitIntroduce from './components/ExhibitIntroduce';
 import TopButton from 'components/TopButton';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import styles from './about.module.scss';
+import useScrollNav from 'utils/hooks/useScrollNav';
 
 const TAB_LIST = ['전시 소개', '학과 소개'];
 
 export default function About() {
   const { tabs, currentTab } = DetailTabs.useTabs(TAB_LIST);
   const isMobile = useMediaQuery();
+  const showNav = useScrollNav();
 
   return (
     <div>
-      <DetailTabs tabs={tabs} selected={currentTab} />
+      <DetailTabs tabs={tabs} selected={currentTab} showNav={showNav} />
       {currentTab === TAB_LIST[0] && <ExhibitIntroduce />}
       {currentTab === TAB_LIST[1] && <MajorIntroduce />}
       {!isMobile && (

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -4,21 +4,25 @@ import MainSection from 'components/Section/Main';
 import MainMobileSection from 'components/Section/MainMobileSection';
 import LocationSection from 'components/Section/Location';
 import styles from './main.module.scss';
+import TopButton from 'components/TopButton';
 
 export default function Main() {
   const { scrollTo, onMoveToElement } = useMoveScroll();
   const isMobile = useMediaQuery();
   return (
     <div className={styles.template}>
-      {
-        isMobile ? (
-          <MainMobileSection onMoveScroll={() => onMoveToElement()} />
-        ) : (
-          <MainSection onMoveScroll={() => onMoveToElement()} />
-        )
-      }
+      {isMobile ? (
+        <MainMobileSection onMoveScroll={() => onMoveToElement()} />
+      ) : (
+        <MainSection onMoveScroll={() => onMoveToElement()} />
+      )}
       <div ref={scrollTo} />
       <LocationSection />
+      {!isMobile && (
+        <div className={styles['top-button']}>
+          <TopButton />
+        </div>
+      )}
     </div>
-  )
+  );
 }

--- a/src/pages/main/main.module.scss
+++ b/src/pages/main/main.module.scss
@@ -1,4 +1,4 @@
-@use "src/utils/scss/media";
+@use 'src/utils/scss/media';
 
 .template {
   width: 100%;
@@ -6,4 +6,15 @@
   @include media.media-breakpoint(mobile) {
     padding-top: 40px;
   }
+}
+
+.top-button {
+  z-index: 1000;
+  position: fixed;
+  right: 30px;
+  bottom: 15px;
+  // :hover {
+  //   cursor: pointer;
+  // }
+  // svg영역이 이상하게 잡혀있어서 오버한 hover가 생김
 }

--- a/src/pages/main/main.module.scss
+++ b/src/pages/main/main.module.scss
@@ -13,8 +13,4 @@
   position: fixed;
   right: 30px;
   bottom: 15px;
-  // :hover {
-  //   cursor: pointer;
-  // }
-  // svg영역이 이상하게 잡혀있어서 오버한 hover가 생김
 }

--- a/src/utils/hooks/useScrollNav.ts
+++ b/src/utils/hooks/useScrollNav.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+function useScrollNav() {
+  const [showNav, setShowNav] = useState(true);
+  const [lastScrollY, setLastScrollY] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+
+      if (currentScrollY > lastScrollY) {
+        setShowNav(false);
+      } else {
+        setShowNav(true);
+      }
+
+      setLastScrollY(currentScrollY);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [lastScrollY]);
+
+  return showNav;
+}
+
+export default useScrollNav;


### PR DESCRIPTION
1. 상단 페이지 상단 스크롤 버튼 구현
  * 해당 구현에 있어 svg에 여백이 들어간 상태로 구현이 되어있어 cusor:pointer의 영역이 이상하게 잡히고 있습니다.     

     => 디자이너 전달 부탁드립니다.  
       > 상단 올리기 버튼 svg의 여백 없는 것으로 부탁드립니다.

<img width="197" alt="image" src="https://github.com/daepan/2024-bala/assets/86779590/cc13b014-b8e7-4c4d-9dd9-b5623475f090">

<br/>   

2. DetailTab 스크롤 방향(올리기, 내리기)에 따른 표현 여부 구현
* 현재 피그마에서 댓글이 달려있는 것은 About, 모바일 부분이기에 해당 부분만 적용해두었습니다.     
* 해당 기능 어느 부분까지 적용인지 체크 해주시면 감사하겠습니다.

