### PR TITLE
1차 QA ABOUT 페이지 내용 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 import Main from './pages/main';
 import IndexPage from './pages/index';
-import About from 'pages/about';
+import About from 'pages/About';
 // import Project from 'pages/Project';
 // import DetailProject from 'pages/DetailProject';
 import Designers from 'pages/Designers';

--- a/src/components/Form/DetailTabs/DetailTabs.module.scss
+++ b/src/components/Form/DetailTabs/DetailTabs.module.scss
@@ -54,7 +54,7 @@
   }
 
   & > span {
-    font-family: Pretendard-Bold;
+    font-family: Pretendard;
     font-style: normal;
     font-weight: 600;
     font-size: 28px;
@@ -76,7 +76,7 @@
 
   &--unchecked {
     color: var(--Primary-50, #7ea1db);
-    font-family: Pretendard-Regular;
+    font-family: Pretendard;
     display: flex;
     padding: 6px 16px;
     justify-content: center;
@@ -133,7 +133,7 @@
   }
 
   & > span {
-    font-family: Pretendard-Bold;
+    font-family: Pretendard;
     font-style: normal;
     font-weight: 600;
     font-size: 28px;
@@ -156,7 +156,7 @@
 
   &--unchecked {
     color: var(--Primary-50, #7ea1db);
-    font-family: Pretendard-Regular;
+    font-family: Pretendard;
     display: flex;
     padding: 6px 16px;
     justify-content: center;

--- a/src/components/MobileHeader/index.tsx
+++ b/src/components/MobileHeader/index.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { ReactComponent as MobileLogo } from 'assets/bala_logo_mobile.svg';
 import { ReactComponent as MobileMenu } from 'assets/main_menu_mobile.svg';
 import { ReactComponent as XIcon } from 'assets/close.svg';
-import { TAB_LIST } from 'pages/about';
+import { TAB_LIST } from 'pages/About';
 import styles from './MobileHeader.module.scss';
 
 export default function MobileHeader() {

--- a/src/index.css
+++ b/src/index.css
@@ -84,5 +84,5 @@ code {
 }
 
 body {
-  font-family: 'Pretendard', sans-serif;
+  font-family: 'Pretendard', Sans-serif;
 }

--- a/src/pages/about/components/ExhibitIntroduce/ExhibitIntroduce.module.scss
+++ b/src/pages/about/components/ExhibitIntroduce/ExhibitIntroduce.module.scss
@@ -278,15 +278,19 @@
   &__detail-title {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    // justify-content: space-between;
     height: 125px;
-    margin-right: 77px;
+    margin-right: 77px;     
+    padding-left: 10px;
+
 
     @include media.media-breakpoint(mobile) {
       width: 50%;
       margin-right: 0;
+      padding-left: 10px;
+      
     }
-
+    
     & > span {
       color: #000;
       /* Medium/20pt */
@@ -323,7 +327,7 @@
     & > span {
       color: #000;
       display: block;
-      margin-bottom: 20px;
+      margin-bottom: 18px;
       /* Medium/20pt */
       font-family: Pretendard;
       font-size: 24px;
@@ -380,6 +384,9 @@
 }
 
 .committee-section {
+      @include media.media-breakpoint(mobile) {
+        width: 375px;
+      }
   &__member-section {
     margin-top: 20px;
 
@@ -398,6 +405,7 @@
 
     @include media.media-breakpoint(mobile) {
       margin-bottom: 0;
+      align-items: flex-start;
     }
   }
 
@@ -426,6 +434,8 @@
   }
 
   &__member-group-unit {
+    display: flex;
+    gap:5px;
     color: #4d4d4d;
     /* Medium/22pt */
     font-family: Pretendard;
@@ -436,9 +446,14 @@
     letter-spacing: -0.242px;
 
     @include media.media-breakpoint(mobile) {
+      display: flex;
+      flex-wrap: wrap;
+    
       color: #000;
       font-family: Pretendard;
-      max-width: 75%;
+      gap:3px;
+      max-width: 245px;
+      // max-width: 75%;
       font-size: 12px;
       font-style: normal;
       font-weight: 300;

--- a/src/pages/about/components/ExhibitIntroduce/index.tsx
+++ b/src/pages/about/components/ExhibitIntroduce/index.tsx
@@ -15,34 +15,35 @@ import { ReactComponent as SeedkeeperIcon } from 'Asset/seedkeeper.svg';
 import { ReactComponent as SmartHumanInterfaceIcon } from 'Asset/smart-human-interface.svg';
 import TopButton from 'components/TopButton';
 
+
 const MEMBERS = [
   {
     group: '위원단장',
-    member: '강호정 황민성'
+    member: ['강호정', '황민성']
   },
   {
     group: '기획부',
-    member: '김이연 오기석 사공도영 이서하 정해민 조용현 천세강'
+    member: ['김이연', '오기석', '이서하', '정해민', '조용현', '천세강', '사공도영']
   },
   {
     group: '진행부 ',
-    member: '박채연 김도훈 박정빈 박지윤 신민우 윤채원 이예빈'
+    member: ['박채연', '김도훈', '박정빈', '박지윤', '신민우', '윤채원', '이예빈']
   },
   {
     group: '총무부',
-    member: '김두언 김수현 이시온'
+    member: ['김두언', '김수현', '이시온']
   },
   {
     group: '편집부',
-    member: '김지민 곽우령 김승규 김익현 백승선 신동찬 이수빈 이한 최성우'
+    member: ['김지민', '곽우령', '김승규', '김익현', '백승선', '신동찬', '이수빈', '최성우', '이한']
   },
   {
     group: '홍보부',
-    member: '김다준 김혜민 이승은 최혁수'
+    member: ['김다준', '김혜민' ,'이승은' ,'최혁수']
   },
   {
     group: '도록부',
-    member: '김채은 김정연 김호빈 원윤섭 최민경 최성일'
+    member: ['김채은', '김정연', '김호빈', '원윤섭', '최민경', '최성일']
   }
 ];
 
@@ -128,15 +129,15 @@ function ExhibitIntroduce() {
             <div className={styles['category-section__detail']}>
               <div className={styles['category-section__detail-type']}>
                 <img src={mobility} alt="mobility" />
-                <span>Mobility</span>
+                <span>MOBILITY ZONE </span>
               </div>
               <div className={styles['category-section__detail-type']}>
                 <img src={care} alt="care" />
-                <span>Care</span>
+                <span>CARE ZONE</span>
               </div>
               <div className={styles['category-section__detail-type']}>
                 <img src={living} alt="living" />
-                <span>Living</span>
+                <span>LIVING ZONE</span>
               </div>
             </div>
           </div>
@@ -144,20 +145,20 @@ function ExhibitIntroduce() {
             <div className={styles['exhibit-section__wrapper']}>
               <div className={styles['title']}>전시 안내도</div>
               <div className={styles['exhibit-section__info']}>
-                각 전시자들의 작품이 전시되어 있는 Exhibition Zone과 전시
+                각 전시자들의 작품이 전시되어 있는 Exhibition Zone과 <br/>전시
                 컨텐츠를 즐길 수 있는 Contents Zone이 있습니다.
               </div>
               <div className={styles['exhibit-section__detail']}>
                 <ul className={styles['exhibit-section__detail-title']}>
                   <span>Exhibition</span>
                   <li className={styles['exhibit-section__detail-info']}>
-                    Mobility
+                    MOBILITY ZONE 
                   </li>
                   <li className={styles['exhibit-section__detail-info']}>
-                    Care
+                    CARE ZONE
                   </li>
                   <li className={styles['exhibit-section__detail-info']}>
-                    Living
+                    LIVING ZONE
                   </li>
                 </ul>
                 <ol className={styles['exhibit-section__detail-title-number']}>
@@ -213,7 +214,10 @@ function ExhibitIntroduce() {
                   <div
                     className={styles['committee-section__member-group-unit']}
                   >
-                    {item.member}
+                    {item.member.map((member) => (
+                      <span key={member}>{member}</span>                   
+                    ))}
+                  
                   </div>
                 </div>
               ))}

--- a/src/pages/about/components/MajorIntroduce/MajorIntroduce.module.scss
+++ b/src/pages/about/components/MajorIntroduce/MajorIntroduce.module.scss
@@ -170,10 +170,11 @@
     & > img {
       width: 224px;
       height: 299px;
-
+      border-radius: 8px;
       @include media.media-breakpoint(mobile) {
         width: 95.36px;
         height: 133.061px;
+        border-radius: 8px;
       }
     }
   }

--- a/src/pages/about/components/MajorIntroduce/index.tsx
+++ b/src/pages/about/components/MajorIntroduce/index.tsx
@@ -33,7 +33,7 @@ export default function MajorIntroduce() {
         산업디자인 기술과 공학적 지식을 활용하여 사용자의 감성과 경험을 충족하는
         스마트제품 및 감성융합서비스 디자인 전문가 양성을 목표로 하고 있다.
         급변하는 현대 산업사회에서 능동적으로 디자인 문제를 발견하고, 창의적인
-        디자인 솔루션을 제시할 수 있는 디자인 전문인력 양성에 중점을 두고 있다
+        디자인 솔루션을 제시할 수 있는 디자인 전문인력 양성에 중점을 두고 있다.
       </div>
       <div className={styles['mobile-major-introduce-title']}>교수진 소개</div>
       <div className={styles['other-professor-section']}>

--- a/src/utils/hooks/useScrollNav.ts
+++ b/src/utils/hooks/useScrollNav.ts
@@ -10,6 +10,9 @@ function useScrollNav() {
 
       if (currentScrollY > lastScrollY) {
         setShowNav(false);
+      }
+      else if(currentScrollY === 0){
+        setShowNav(true); // 최상단일 때는 nav바를 항상 보여줌
       } else {
         setShowNav(true);
       }


### PR DESCRIPTION
## Page 4. 
* 전시 소개 padding  맞춰주세요 
=> 현재 중앙정렬이 되어있는 상태입니다. 이는 해당 QA 적용 후 배포 된 사이트에서 다시 확인해보겠습니다.
* 졸업준비위원회 파트
=> 편집부 정렬 맞춤
=> 편집부 인원 줄바꿈 적용

## Page 5.
* 전시 안내도 간격 확인 및 ZONE 워딩 수정
=> 간격 수정 및 워딩 수정하였습니다.


## Page 6.
* 학과 소개 색상 확인
=> 색상 확인 결과 피그마에서 사용된 색상입니다. 아마 핸드폰 기종에 따른 색상 표현의 차이일 것 같습니다.
* 교수님 사진 border-radius 추가
=> 해당 부분 8px 추가하였습니다.

## Page 7.
* 전시소개 | 학과 소개 간격 체크
해당 부분 간격은 현재 중앙 정렬로 되어있습니다.
* 포스터랑 탭 UI 1px 차이
=> 이는 safari에서 나타나는 문제로 파악됩니다.
해당 부분은 추가적인 브라우저에서 확인 후 진행 해야 할 것 같습니다
* 전시 소개 페이지 간격
=>해당 부분 파악하고 수정해보았습니다. 모바일로 확인할 수 없어 기능적으로 확인은 못하였고, 배포 후 확인 가능 할 것 같습니다. / 해결 방법으로는 스크롤이 최상단일때는 top nav가 매번 보이게 구현하였습니다.


----

## 공통 이슈

* 사파리로 봤을 떄 서체 깨짐  => 노트북 사파리 개발 환경에서 보았을 때 깨지는 것은 수정하였습니다. 또 이상한 부분이 있으면 말씀해주세요

* 웹 반응형 부자연스러움 => 반응형에 따른 UI대응 디자인 부재로 임의로 작업함이 크게 작용했다고 생각합니다. 많이 부자연 스러운 부분은 디자인 측과 이야기후 추가개발이 필요할 것같습니다

* 웹 페이지 확대 축소 잠글 수 있나 => 이것은 잘 모르겠네요 찾아보겠습니다.

* 테스트 환경따라 달라보이나요? => 네. 특히 사파리의 경우 호환이 많이 안되고 디자인 적으로도 웹 사이트와 다르게 보이곤 합니다. 아이폰의 경우에는 크롬으로 접속하여도 사파리 브라우저 위에서 돌기때문에 사파리에서 나타나는 이슈가 생깁니다. 해당 부분은 개발측에 전달해주시면 최대한 고쳐보겠습니다.
